### PR TITLE
initial build fixes for BetterJunimosForestry

### DIFF
--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/ChopTreesAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/ChopTreesAbility.cs
@@ -98,7 +98,7 @@ namespace BetterJunimosForestry.Abilities {
             return (tile * Game1.tileSize) + new Vector2(Game1.tileSize / 2f);
         }
 
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new();
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/CollectDroppedObjectsAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/CollectDroppedObjectsAbility.cs
@@ -45,7 +45,7 @@ namespace BetterJunimosForestry.Abilities {
         }
 
         public bool PerformAction(GameLocation location, Vector2 pos, JunimoHarvester junimo, Guid guid) {
-            var chest = Util.GetHutFromId(guid).output.Value;
+            var chest = Util.GetHutFromId(guid).GetOutputChest();
 
             var (x, y) = pos;
             var up = new Vector2(x, y + 1);
@@ -57,7 +57,7 @@ namespace BetterJunimosForestry.Abilities {
             Vector2[] positions = { up, right, down, left };
             foreach (var nextPos in positions) {
                 if (!Util.IsWithinRadius(location, Util.GetHutFromId(guid), nextPos)) continue;
-                if (DebrisIndexAtTile(nextPos) > 0) {
+                if (DebrisIndexAtTile(nextPos) != "") {
                     junimo.faceDirection(direction);
                     return MoveDebrisFromTileToChest(nextPos, location, chest);
                 }
@@ -67,13 +67,13 @@ namespace BetterJunimosForestry.Abilities {
         }
 
         protected bool IsDebrisAtTile(Vector2 tile) {
-            return DebrisIndexAtTile(tile) > 0;
+            return DebrisIndexAtTile(tile) != "";
         }
 
-        protected int DebrisIndexAtTile(Vector2 tile) { 
+        protected string DebrisIndexAtTile(Vector2 tile) {
             // Monitor.Log($"IsDebrisAtTile {tile}", LogLevel.Debug);
             if (Game1.currentLocation.debris is null) {
-                return -1;
+                return "";
             }
             foreach (Debris d in Game1.currentLocation.debris) {
                 foreach (Chunk c in d.Chunks) {
@@ -83,16 +83,12 @@ namespace BetterJunimosForestry.Abilities {
                         // Monitor.Log($"        Debris chunks: {d.Chunks.Count} type: {d.debrisType} at {dx},{dy}", LogLevel.Debug);
                         if (d.item is not null) {
                             // Monitor.Log($"            {d.item.Name} [{d.item.ParentSheetIndex}]", LogLevel.Debug);
-                            return d.item.ParentSheetIndex;
-                        }
-                        else {
-                            // Monitor.Log($"            non-item debris [{c.debrisType}]", LogLevel.Debug);
-                            return c.debrisType;
+                            return d.item.ItemId;
                         }
                     }
                 }
             }
-            return 0;
+            return "";
         }
 
         protected bool MoveDebrisFromTileToChest(Vector2 tile, GameLocation farm, Chest chest) {
@@ -123,20 +119,14 @@ namespace BetterJunimosForestry.Abilities {
         protected void MoveDebrisToChest(Debris d, GameLocation farm, Chest chest) {
             foreach (Chunk c in d.Chunks) {
                 if (d.item is not null) {
-                    SObject item = new SObject(d.item.ParentSheetIndex, 1);
+                    SObject item = new SObject(d.item.ItemId, 1);
                     Util.AddItemToChest(farm, chest, item);
                     //Monitor.Log($"            MoveDebrisToChest {d.item.Name} [{d.item.ParentSheetIndex}]", LogLevel.Debug);
-                } else {
-                    SObject item = new SObject(c.debrisType, 1);
-                    if (item.Name != "Error Item") {
-                        Util.AddItemToChest(farm, chest, item);
-                        //Monitor.Log($"            MoveDebrisToChest {item.Name} [{c.debrisType}]", LogLevel.Debug);
-                    }
                 }
             }
         }
         
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new();
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/CollectSeedsAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/CollectSeedsAbility.cs
@@ -51,7 +51,7 @@ namespace BetterJunimosForestry.Abilities
             if (t is not Tree tree) return false;
             if (tree.growthStage.Value != 0) return false;
             if (mode == Modes.Normal) return false;
-            if (mode == Modes.Forest && PlantTreesAbility.IsTileInPattern(t.currentTileLocation)) return false;
+            if (mode == Modes.Forest && PlantTreesAbility.IsTileInPattern(t.Tile)) return false;
             return true;
         }
         
@@ -66,7 +66,7 @@ namespace BetterJunimosForestry.Abilities
             return tile * Game1.tileSize + new Vector2(Game1.tileSize / 2f);
         }
 
-        public List<int> RequiredItems()
+        public List<string> RequiredItems()
         {
             return new();
         }

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/FertilizeTreesAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/FertilizeTreesAbility.cs
@@ -10,7 +10,7 @@ using StardewValley.TerrainFeatures;
 
 namespace BetterJunimosForestry.Abilities {
     public class FertilizeTreesAbility : IJunimoAbility {
-        private const int tree_fertilizer = 805;
+        private const string tree_fertilizer = "805";
 
         public string AbilityName() {
             return "FertilizeTrees";
@@ -23,18 +23,18 @@ namespace BetterJunimosForestry.Abilities {
         }
 
         public bool PerformAction(GameLocation farm, Vector2 pos, JunimoHarvester junimo, Guid guid) {
-            var chest = Util.GetHutFromId(guid).output.Value;
-            var foundItem = chest.items.FirstOrDefault(item => item is {ParentSheetIndex: tree_fertilizer});
+            var chest = Util.GetHutFromId(guid).GetOutputChest();
+            var foundItem = chest.Items.FirstOrDefault(item => item is {ItemId: tree_fertilizer});
             if (foundItem == null) return false;
 
             if (farm.terrainFeatures[pos] is not Tree t) return false;
-            t.fertilize(farm);
+            t.fertilize();
             Util.RemoveItemFromChest(chest, foundItem);
             return true;
 
         }
 
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new() { tree_fertilizer };
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestDebrisAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestDebrisAbility.cs
@@ -18,7 +18,7 @@ namespace BetterJunimosForestry.Abilities {
         private readonly FakeFarmer FakeFarmer = new();
         private readonly Pickaxe FakePickaxe = new();
         private readonly Axe FakeAxe = new();
-        private readonly MeleeWeapon Scythe = new(47);
+        private readonly MeleeWeapon Scythe = new("47");
 
         internal HarvestDebrisAbility(IMonitor Monitor) {
             this.Monitor = Monitor;
@@ -93,7 +93,7 @@ namespace BetterJunimosForestry.Abilities {
 
                     if (IsWeed(item)) {
                         UseToolOnTile(Scythe, nextPos, location);
-                        item.performToolAction(Scythe, location);
+                        item.performToolAction(Scythe);
                         location.removeObject(nextPos, false);
                     }
                     
@@ -123,7 +123,7 @@ namespace BetterJunimosForestry.Abilities {
             return tile * Game1.tileSize + new Vector2(Game1.tileSize / 2f);
         }
 
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new();
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestFruitTreesAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestFruitTreesAbility.cs
@@ -22,7 +22,7 @@ namespace BetterJunimosForestry.Abilities {
         }
 
         private static bool IsHarvestableFruitTree(TerrainFeature tf) {
-            return tf is FruitTree tree && tree.fruitsOnTree.Value > 0;
+            return tf is FruitTree tree && tree.fruit.Any();
         }
 
         public bool IsActionAvailable(GameLocation location, Vector2 pos, Guid guid) {
@@ -61,40 +61,21 @@ namespace BetterJunimosForestry.Abilities {
             return false;
         }
 
-        /// <summary>Harvest fruit from a FruitTree and update the tree accordingly.</summary>
-        private static SObject GetFruitFromTree(FruitTree tree) {
-            if (tree.fruitsOnTree.Value == 0)
-                return null;
-
-            var quality = 0;
-            if (tree.daysUntilMature.Value <= -112)
-                quality = 1;
-            if (tree.daysUntilMature.Value <= -224)
-                quality = 2;
-            if (tree.daysUntilMature.Value <= -336)
-                quality = 4;
-            if (tree.struckByLightningCountdown.Value > 0)
-                quality = 0;
-
-            tree.fruitsOnTree.Value --;
-
-            var result = new SObject(Vector2.Zero, tree.struckByLightningCountdown.Value > 0 ? 382 : tree.indexOfFruit.Value, 1) { Quality = quality };
-            return result;
-        }
-
         private static bool HarvestFromTree(Vector2 pos, JunimoHarvester junimo, FruitTree tree) {
-            //shake the tree without it releasing any fruit
-            var fruitsOnTree = tree.fruitsOnTree.Value;
-            tree.fruitsOnTree.Value = 0;
-            tree.performUseAction(pos, junimo.currentLocation);
-            tree.fruitsOnTree.Value = fruitsOnTree;
-            var result = GetFruitFromTree(tree);
-            if (result == null) return false;
-            junimo.tryToAddItemToHut(result);
+            // do nothing if the tree has no item
+            if (!tree.fruit.Any())
+                return false;
+
+            // take all the item first
+            foreach (var item in tree.fruit)
+                junimo.tryToAddItemToHut(item);
+            tree.fruit.Clear();
+            // shake the tree after
+            tree.performUseAction(pos);
             return true;
         }
 
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new();
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestGrass.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/HarvestGrass.cs
@@ -49,7 +49,7 @@ namespace BetterJunimosForestry.Abilities {
             return true;
         }
 
-        public List<int> RequiredItems() {
+        public List<string> RequiredItems() {
             return new();
         }
         

--- a/BetterJunimosForestry/BetterJunimosForestry/Abilities/PlantTreesAbility.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Abilities/PlantTreesAbility.cs
@@ -63,10 +63,10 @@ namespace BetterJunimosForestry.Abilities
 
         public bool PerformAction(GameLocation location, Vector2 pos, JunimoHarvester junimo, Guid guid)
         {
-            var hut = Util.GetHutFromId(guid);
-            var chest = hut.output.Value;
-            var foundItem = chest.items.FirstOrDefault(item =>
-                item != null && Util.WildTreeSeeds.Keys.Contains(item.ParentSheetIndex));
+            JunimoHut hut = Util.GetHutFromId(guid);
+            var chest = hut.GetOutputChest();
+            var foundItem = chest.Items.FirstOrDefault(item =>
+                item != null && Util.WildTreeSeeds.Keys.Contains(item.ItemId));
             if (foundItem == null) return false;
 
             var (x, y) = pos;
@@ -80,7 +80,7 @@ namespace BetterJunimosForestry.Abilities
             {
                 if (!Util.IsWithinRadius(location, hut, nextPos)) continue;
                 if (!ShouldPlantWildTreeHere(location, hut, nextPos)) continue;
-                if (!Plant(location, nextPos, foundItem.ParentSheetIndex)) continue;
+                if (!Plant(location, nextPos, foundItem.ItemId)) continue;
                 Util.RemoveItemFromChest(chest, foundItem);
                 return true;
             }
@@ -118,7 +118,7 @@ namespace BetterJunimosForestry.Abilities
         {
             // is something standing on it? an impassable building? a terrain feature?
             // we want to use the game's occupied check, but also allow for un-hoeing empty hoedirt
-            if (location.isTileOccupied(pos) && !Util.IsHoed(location, pos)) return false;
+            if (location.IsTileOccupiedBy(pos) && !Util.IsHoed(location, pos)) return false;
 
             if (Util.HasCrop(location, pos)) return false;
             if (Util.IsOccupied(location, pos)) return false;
@@ -127,7 +127,7 @@ namespace BetterJunimosForestry.Abilities
             return true;
         }
 
-        private bool Plant(GameLocation location, Vector2 pos, int index)
+        private bool Plant(GameLocation location, Vector2 pos, string id)
         {
             // check if the tile needs to be un-hoed
             if (location.terrainFeatures.TryGetValue(pos, out var feature))
@@ -144,7 +144,7 @@ namespace BetterJunimosForestry.Abilities
                 return false;
             }
 
-            var tree = new Tree(Util.WildTreeSeeds[index], ModEntry.Config.PlantWildTreesSize);
+            var tree = new Tree(Util.WildTreeSeeds[id], ModEntry.Config.PlantWildTreesSize);
             location.terrainFeatures.Add(pos, tree);
 
             if (Utility.isOnScreen(Utility.Vector2ToPoint(pos), 64, location))
@@ -158,7 +158,7 @@ namespace BetterJunimosForestry.Abilities
         }
 
 
-        public List<int> RequiredItems()
+        public List<string> RequiredItems()
         {
             return Util.WildTreeSeeds.Keys.ToList();
         }

--- a/BetterJunimosForestry/BetterJunimosForestry/BetterJunimosForestry.csproj
+++ b/BetterJunimosForestry/BetterJunimosForestry/BetterJunimosForestry.csproj
@@ -4,16 +4,17 @@
     <AssemblyName>BetterJunimosForestry</AssemblyName>
     <RootNamespace>BetterJunimosForestry</RootNamespace>
     <Version>1.0.7-beta9</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="BetterJunimos">
-      <HintPath>../../../hawkfalcon-Stardew-Mods/BetterJunimos/bin/Debug/net5.0/BetterJunimos.dll</HintPath>
+      <HintPath>../../../HawkFalconStardewMods/BetterJunimos/bin/Debug/net6.0/BetterJunimos.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/BetterJunimosForestry/BetterJunimosForestry/ModEntry.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/ModEntry.cs
@@ -238,8 +238,8 @@ namespace BetterJunimosForestry {
                 Monitor.Log($"Could not load Better Junimos API", LogLevel.Error);
             }
             
-            icons = Helper.Content.Load<Texture2D>("assets/icons.png");
-            scroll = Helper.Content.Load<Texture2D>("assets/scroll2.png");
+            icons = Helper.ModContent.Load<Texture2D>("assets/icons.png");
+            scroll = Helper.ModContent.Load<Texture2D>("assets/scroll2.png");
 
             // BJApi.RegisterJunimoAbility(new Abilities.LayPathsAbility(Monitor));
             // Abilities now registered in OnSaveLoaded
@@ -327,7 +327,7 @@ namespace BetterJunimosForestry {
             }
 
             // reset for rainy days, winter, or GMCM options change
-            Helper.Content.InvalidateCache(@"Characters\Junimo");
+            Helper.GameContent.InvalidateCache(@"Characters\Junimo");
         }
         
         /*********

--- a/BetterJunimosForestry/BetterJunimosForestry/Util.cs
+++ b/BetterJunimosForestry/BetterJunimosForestry/Util.cs
@@ -24,13 +24,13 @@ namespace BetterJunimosForestry {
     }
     
     public static class Util {
-        internal static readonly Dictionary<int, int> WildTreeSeeds = new()
+        internal static readonly Dictionary<string, string> WildTreeSeeds = new()
         {
-            {292, 8}, // mahogany
-            {309, 1}, // acorn
-            {310, 2}, // maple
-            {311, 3}, // pine
-            {891, 7}  // mushroom
+            {"292", "8"}, // mahogany
+            {"309", "1"}, // acorn
+            {"310", "2"}, // maple
+            {"311", "3"}, // pine
+            {"891", "7"}  // mushroom
         };
         
         /// <summary>Get whether a tile is blocked due to something it contains.</summary>
@@ -44,7 +44,7 @@ namespace BetterJunimosForestry {
                 return true;
 
             // objects & large terrain features
-            if (location.objects.ContainsKey(tile) || location.largeTerrainFeatures.Any(p => p.tilePosition.Value == tile))
+            if (location.objects.ContainsKey(tile) || location.largeTerrainFeatures.Any(p => p.Tile == tile))
                 return true;
             
             // logs, boulders, etc
@@ -62,11 +62,8 @@ namespace BetterJunimosForestry {
             }
 
             // buildings
-            if (location is BuildableGameLocation buildableLocation)
-            {
-                if (buildableLocation.buildings.Any(building => building.occupiesTile(tile)))
+             if (location.buildings.Any(building => building.occupiesTile(tile)))
                     return true;
-            }
 
             // buildings from the map
             if (location.getTileIndexAt(Utility.Vector2ToPoint(tile), "Buildings") > -1) return true;
@@ -221,19 +218,19 @@ namespace BetterJunimosForestry {
             return null;
         }
         
-        public static void AddItemToChest(GameLocation farm, Chest chest, SObject item) {
+        public static void AddItemToChest(GameLocation farm, Chest chest, Item item) {
             Item obj = chest.addItem(item);
             if (obj == null) return;
             Vector2 pos = chest.TileLocation;
             for (int index = 0; index < obj.Stack; ++index)
-                Game1.createObjectDebris(item.ParentSheetIndex, (int)pos.X + 1, (int)pos.Y + 1, -1, item.Quality, 1f, farm);
+                Game1.createObjectDebris(item.ItemId, (int)pos.X + 1, (int)pos.Y + 1, -1, item.Quality, 1f, farm);
         }
 
         public static void RemoveItemFromChest(Chest chest, Item item) {
             if (ModEntry.Config.InfiniteJunimoInventory) { return; }
             item.Stack--;
             if (item.Stack == 0) {
-                chest.items.Remove(item);
+                chest.Items.Remove(item);
             }
         }
         


### PR DESCRIPTION
This attempts to fix the BetterJunimosForestry mod to work with Stardew
Valley 1.6, though it is currently build-tested only.

The big changes include:

* switching to string IDs instead of numerical indexes
* fixing many function references
* re-wrote the fruit tree harvest logic entirely
* removed a bunch of references to debris logic that appears to have
  been removed from Stardew Valley 1.6
* Update the target to net6.0, and update the ModBuildConfig and JSON
  references.
* Various other fixes require to get things compiling

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
